### PR TITLE
Marker+Spawnercard link, some minor things

### DIFF
--- a/app/component/assetsPanel/assetsPanel.html
+++ b/app/component/assetsPanel/assetsPanel.html
@@ -18,7 +18,7 @@
 
     <!-- Always Team 1 (DESKTOP only)-->
     <div class="spawner-card-wrapper desktop-only"> 
-            <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids" ng-mouseleave="$ctrl.spawnerhover = undefined" ng-click="$emit('spawnerjump', spawner.uids);">
+        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids" ng-mouseleave="$ctrl.spawnerhover = undefined" ng-click="$emit('spawnerjump', spawner.uids);">
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>

--- a/app/component/assetsPanel/assetsPanel.html
+++ b/app/component/assetsPanel/assetsPanel.html
@@ -18,7 +18,7 @@
 
     <!-- Always Team 1 (DESKTOP only)-->
     <div class="spawner-card-wrapper desktop-only"> 
-        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )"> 
+            <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>
@@ -39,7 +39,7 @@
 
     <!-- Always Team 2 (DESKTOP only) -->
     <div class="spawner-card-wrapper desktop-only"> 
-        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 1 )"> 
+        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 1 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>
@@ -59,7 +59,7 @@
 
     <!-- May be Team 1 or 2 (MOBILE only) -->
     <div class="spawner-card-wrapper mobile-only"> 
-        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( $ctrl.Team )"> 
+        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( $ctrl.Team )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>

--- a/app/component/assetsPanel/assetsPanel.html
+++ b/app/component/assetsPanel/assetsPanel.html
@@ -18,7 +18,7 @@
 
     <!-- Always Team 1 (DESKTOP only)-->
     <div class="spawner-card-wrapper desktop-only"> 
-            <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
+            <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 0 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids" ng-mouseleave="$ctrl.spawnerhover = undefined" ng-click="$emit('spawnerjump', spawner.uids);">
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>
@@ -39,7 +39,7 @@
 
     <!-- Always Team 2 (DESKTOP only) -->
     <div class="spawner-card-wrapper desktop-only"> 
-        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 1 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
+        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( 1 )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids" ng-mouseleave="$ctrl.spawnerhover = undefined" ng-click="$emit('spawnerjump', spawner.uids);"> 
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>
@@ -59,7 +59,7 @@
 
     <!-- May be Team 1 or 2 (MOBILE only) -->
     <div class="spawner-card-wrapper mobile-only"> 
-        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( $ctrl.Team )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids"> 
+        <div class="spawner-card" ng-repeat="spawner in $ctrl.GetAssets( $ctrl.Team )" ng-class="spawner.uids.indexOf($ctrl.spawnerhover[0]) !== -1 ? 'hover':''" ng-mouseover="$ctrl.spawnerhover = spawner.uids" ng-mouseleave="$ctrl.spawnerhover = undefined" ng-click="$emit('spawnerjump', spawner.uids);"> 
             <div class="spawnwer-icon icon-asset" ng-class="spawner.Vehicle.Icon"></div>
             <div class="spawnwer-info">
                 <div class="spawnwer-name">{{spawner.Vehicle.Name}}</div>

--- a/app/component/assetsPanel/assetsPanel.scss
+++ b/app/component/assetsPanel/assetsPanel.scss
@@ -96,6 +96,8 @@ assets-panel{
                     height: 16px;
                     margin: 0px 15px 0 10px;
                     transform: scale(calc(32 / 16));
+                    image-rendering: optimizespeed; // Force pixelation. Only works on FF
+                    image-rendering: pixelated; // Only works on Chrome
                 }
                 .spawnwer-info{
                     width: 100%;

--- a/app/component/assetsPanel/assetsPanel.scss
+++ b/app/component/assetsPanel/assetsPanel.scss
@@ -82,6 +82,7 @@ assets-panel{
                 display: flex;
                 flex-direction: row;
                 align-items: center;
+                cursor:pointer;
                 padding: 15px 10px; 
                 &:hover{
                     background: rgba(255, 255, 255, 0.1);

--- a/app/component/assetsPanel/assetsPanel.scss
+++ b/app/component/assetsPanel/assetsPanel.scss
@@ -86,10 +86,15 @@ assets-panel{
                 &:hover{
                     background: rgba(255, 255, 255, 0.1);
                 }
+                
+                &.hover{
+                    background: rgba(255, 255, 255, 0.1);
+                }
                 .spawnwer-icon{
                     width: 16px;
                     height: 16px;
                     margin: 0px 15px 0 10px;
+                    transform: scale(calc(32 / 16));
                 }
                 .spawnwer-info{
                     width: 100%;

--- a/app/component/assetsPanel/assetsPanel.ts
+++ b/app/component/assetsPanel/assetsPanel.ts
@@ -4,9 +4,10 @@ import { Team } from '../../model/Team';
 
 interface SpawnerExtended extends Spawner {
     Quantity: number;
+    uids :  number[];
 }
 
-class AssetsPanelComponent implements ng.IComponentController {
+class AssetsPanelComponent implements ng.IController {
 
     // binding properties
     private assets: Spawner[];
@@ -48,8 +49,11 @@ class AssetsPanelComponent implements ng.IComponentController {
                 if (extendedAssets[spawner.Team][key] === undefined) {
                     extendedAssets[spawner.Team][key] = <SpawnerExtended>spawner;
                     extendedAssets[spawner.Team][key].Quantity = 1;
-                } else
+                    extendedAssets[spawner.Team][key].uids = [spawner.uid ];
+                } else {
                     extendedAssets[spawner.Team][key].Quantity += 1;
+                    extendedAssets[spawner.Team][key].uids.push(spawner.uid);
+                }
             }
 
             // Get all values from dictionary, sort them and set the variable
@@ -172,6 +176,7 @@ angular
         controller: AssetsPanelComponent,
         bindings: {
             assets: '<',
-            teams: '<'
+            teams: '<',
+            spawnerhover: '='
         }
     });

--- a/app/component/mapDetails/mapDetails.html
+++ b/app/component/mapDetails/mapDetails.html
@@ -14,7 +14,7 @@
                 </div>
 
                 <div class="panel-element mobile-only" panel-show="$ctrl.ShowAssetsPanel">
-                    <assets-panel assets="$ctrl.layout.Assets" teams="$ctrl.layout.Team" ></assets-panel>
+                    <assets-panel assets="$ctrl.layout.Assets" teams="$ctrl.layout.Team" spawnerhover="$ctrl.spawnerhover"></assets-panel>
                 </div>
 
             </div>
@@ -32,7 +32,7 @@
 </div>
     <div class="assets-sidebar desktop-only" ng-class="{hide: $ctrl.HideSideBar}">
         <div class="slider">
-                <assets-panel assets="$ctrl.layout.Assets" teams="$ctrl.layout.Team" ></assets-panel>
+                <assets-panel assets="$ctrl.layout.Assets" teams="$ctrl.layout.Team" spawnerhover="$ctrl.spawnerhover"></assets-panel>
         </div>
     </div>
     

--- a/app/component/mapDetails/mapDetails.ts
+++ b/app/component/mapDetails/mapDetails.ts
@@ -13,14 +13,14 @@ import { ToolbarService } from '../../service/ToolbarService/ToolbarService';
 
 
 let COLORS = [
-    "#1abc9c",
-    "#2ecc71",
-    "#3498db",
-    "#9b59b6 ",
-    "#f1c40f",
-    "#e67e22",
-    "#e74c3c"
-];
+    "#003aad",
+    "#d56c00",
+    "#8c59ff",
+    "#008a39",
+    "#ff58a1",
+    "#617100",
+    "#63185e"
+]
 
 export interface VehicleMarkerOptions extends L.MarkerOptions {
     bf2properties: {
@@ -164,8 +164,6 @@ class MapDetailsComponent implements router.Ng1Controller {
 
         
         this.$scope.$watch(() => this.spawnerhover, function(newValue, oldValue) {
-            // console.log(this.spawnerhover + ' --> ' + oldValue + ' --> ' + newValue);
-            let mdc = this;
             this.mVehicleLayer.eachLayer(function(layer) {
                 layer = <VehicleMarker> layer;
                 if (this.spawnerhover == undefined ||this.spawnerhover.indexOf(layer.options.bf2properties.uid) !== -1) {
@@ -174,7 +172,7 @@ class MapDetailsComponent implements router.Ng1Controller {
                 } else {
                     layer.setOpacity(0.2);
                 }
-            }, mdc);
+            }, this);
         }.bind(this));
         
         this.$scope.$on('spawnerjump', (e, args)=>{
@@ -190,7 +188,7 @@ class MapDetailsComponent implements router.Ng1Controller {
             this.mVehicleLayer.eachLayer(function(layer) {
                 let marker = <VehicleMarker> layer;
                 if (marker.options.bf2properties.uid == this.spawnerjumper) {
-                    this.mMap.panTo(marker.getLatLng());
+                    this.mMap.flyTo(marker.getLatLng(), this.mMap.getMaxZoom() - Math.round(this.mMap.getMaxZoom() /3));
                 }
             }, this)
             

--- a/app/component/mapDetails/mapDetails.ts
+++ b/app/component/mapDetails/mapDetails.ts
@@ -43,6 +43,7 @@ class MapDetailsComponent implements router.Ng1Controller {
     private mMaxZoomAdd = 4;
     private mIconManager: IconManager = new IconManager();
     private $transition$;
+    public spawnerhover : number[];
     constructor(private $q: angular.IQService, private MapService: MapService, private $state: router.StateService, private mToolbarService: ToolbarService, private $scope: angular.IScope, $transition) {
         // Do nothing...  
 
@@ -57,7 +58,7 @@ class MapDetailsComponent implements router.Ng1Controller {
             center: new L.LatLng(0, 0),
             crs: L.CRS.Simple,
             zoom: 0,
-            zoomControl: false
+            zoomControl: false,
         });
 
         // Set the scale and maximum zoom acording to the level
@@ -142,6 +143,20 @@ class MapDetailsComponent implements router.Ng1Controller {
         // Render the layout
         this.RenderLayout();
 
+        
+        this.$scope.$watch(() => this.spawnerhover, function(newValue, oldValue) {
+            // console.log(this.spawnerhover + ' --> ' + oldValue + ' --> ' + newValue);
+            let mdc = this;
+            this.mVehicleLayer.eachLayer(function(layer) {
+                layer = <L.Marker> layer;
+                if (this.spawnerhover == undefined ||this.spawnerhover.indexOf(layer.options.bf2properties.uid) !== -1) {
+                    layer.setOpacity(1);
+                    layer.setIc
+                } else {
+                    layer.setOpacity(0.5);
+                }
+            }, mdc);
+        }.bind(this));
         // Zoom to fit
         //this.mMap.fitWorld();
         this.mMap.fitBounds(new L.LatLngBounds(this.mMap.unproject(L.point(0, 0), this.MaxZoom), this.mMap.unproject(L.point(this.mScale, this.mScale), this.MaxZoom)));
@@ -286,12 +301,26 @@ class MapDetailsComponent implements router.Ng1Controller {
             // We need to cast 'L.MarkerOptions' cause we use a plugin that adds 'rotationAngle' and TS cant handle that
             var markerOptions: L.MarkerOptions = <L.MarkerOptions>{
                 icon: icon,
+                title: spawner.Vehicle.Name,
+                bf2properties: {
+                    name: spawner.Vehicle.Name,
+                    code: spawner.Vehicle.Key,
+                    uid: spawner.uid
+                },
                 rotationAngle: spawner.Rotation.X,
                 rotationOrigin: 'center center',
-                interactive: false
+                interactive: true
             };
-
-            L.marker(this.Unproject(spawner.Position.X, spawner.Position.Z), markerOptions).addTo(layer);
+            let marker = new L.Marker(this.Unproject(spawner.Position.X, spawner.Position.Z), markerOptions);
+            marker.on('mouseover',function(ev) {
+                this.spawnerhover = [ev.target.options.bf2properties.uid];
+                this.$scope.$apply();
+            }, this);
+            marker.on('mouseout',function(ev) {
+                this.spawnerhover = undefined;
+                this.$scope.$apply();
+            }, this);
+            marker.addTo(layer);
         }
     }
     private RenderLayout() {
@@ -356,7 +385,15 @@ class MapDetailsComponent implements router.Ng1Controller {
         if (!cp.UnableToChangeTeam) {
             let radius = (cp.Radius * 256) / this.mScale;
 
-            L.circle(this.Unproject(cp.Position.X, cp.Position.Z), { radius: radius, color: COLORS[route - 1], stroke: false, interactive: false }).addTo(layer);
+            L.circle(this.Unproject(cp.Position.X, cp.Position.Z), {
+                radius: radius, 
+                color: COLORS[route - 1], 
+                stroke: true, 
+                weight: 1,
+                opacity: 0.5,
+                fillOpacity: 0.1,
+                interactive: false
+            }).addTo(layer);
         }
 
     }
@@ -458,7 +495,7 @@ class MapDetailsComponent implements router.Ng1Controller {
     private RenderCombatAreas(layer: L.LayerGroup) {
         for (let k = 0; k < this.layout.CombatAreas.length; k++) {
             let dod = this.layout.CombatAreas[k];
-
+            
             let polygon = [];
             for (let j = 0; j < dod.Points.length; j++) {
                 polygon.push(this.Unproject(dod.Points[j].X, dod.Points[j].Y));
@@ -480,10 +517,12 @@ class MapDetailsComponent implements router.Ng1Controller {
 
 
             let color: string;
+            let fillOpacity = 0.2;
 
             switch (dod.Team) {
                 case 0:
                     color = "black";
+                    fillOpacity = 0.5;
                     break;
                 case 1:
                     color = "#2c99af";
@@ -494,7 +533,14 @@ class MapDetailsComponent implements router.Ng1Controller {
             }
 
             // Add the polygon to layer
-            L.polygon(latlngs, { color: color, stroke: false, interactive: false }).addTo(layer);
+            L.polygon(latlngs, { 
+                color: color, 
+                stroke: true,
+                weight: 1,
+                opacity: 0.7,
+                fillOpacity: fillOpacity,
+                interactive: false
+            }).addTo(layer);
         }
     }
 

--- a/app/libs/PRGraticule.ts
+++ b/app/libs/PRGraticule.ts
@@ -53,7 +53,6 @@ export class PRGraticule extends L.LayerGroup{
     }
 
     public onRemove(map:L.Map) {
-        console.log('remove')
         map.off('viewreset '+ this.mOptions.redraw, undefined, this);
         this.labels.eachLayer(map.removeLayer, map);
         this.lines.eachLayer(map.removeLayer, map);

--- a/app/model/Spawner.ts
+++ b/app/model/Spawner.ts
@@ -2,6 +2,7 @@ import { Vector3 } from './Vector';
 import { Vehicle } from './Vehicle';
 
 export interface Spawner {
+    uid : number;
     Key: string;
     Vehicle: Vehicle;
     InitialDelay: number;

--- a/app/service/MapService/MapService.ts
+++ b/app/service/MapService/MapService.ts
@@ -75,6 +75,7 @@ export class MapService {
 
                         for (let k = 0; k < level.Assets.length; k++) {
                             let spawner: Spawner = level.Assets[k];
+                            spawner.uid = k+1;
                             spawner.Vehicle = vehicles[spawner.Key];
                         }
 


### PR DESCRIPTION
- Markers and spawnercards are linked. Hover over one, the corresponding card/marker gets highlighted
- When clicking on a spawnercard, the map pans to the corresponding marker (no zoom, just pan)
- Vehicle name shows when hovering over an icon (title)
- Added slight stroke outline to flags and DoDs
- Decreased opacity for neutral DoD (black/grey is more tricky to see than colored ones)
- Doubled size of spawner icons in spawner cards

Fixes #4 , #5 , #8 